### PR TITLE
Add: yarn start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,8 @@
   "private": false,
   "devDependencies": {
     "gitbook-cli": "^2.3.2"
+  },
+  "scripts": {
+    "start": "yarn gitbook serve"
   }
 }


### PR DESCRIPTION
`README.md`に
```
yarn start
```
と書いているにも関わらず
、`package.json`のscriptsにstartが定義されていませんでした。
`yarn start`を実行できるようにしたプルリクです。